### PR TITLE
PROPINQ-114: Registro, activación y enrutamiento API (frontend)

### DIFF
--- a/.cursor/CONVENTIONS.md
+++ b/.cursor/CONVENTIONS.md
@@ -1,0 +1,93 @@
+# Project Conventions and Practices
+
+This document outlines the architectural patterns, naming conventions, and coding practices used in the `propinq-frontend` Angular project. The goal is to provide a consistent and maintainable codebase.
+
+## 1. Architecture
+
+The project follows a **modular architecture** with a clear separation of concerns.
+
+### 1.1 Module Structure
+
+The `src/app` directory is divided into logical modules, each representing a distinct feature or domain of the application (e.g., `auth`, `buildings`, `contacts`, `maps`, `shared`, `users`).
+
+Each module typically contains the following subdirectories:
+
+*   `components/`: Houses reusable UI components specific to the module.
+*   `dialogs/`: Contains components used as dialogs (e.g., for forms, confirmations).
+*   `interfaces/`: Defines TypeScript interfaces for data models and types used within the module.
+*   `enums/`: Defines TypeScript enumerations for sets of named constant values.
+*   `pages/`: Contains top-level components that represent full pages or views in the application.
+*   `services/`: Provides services for data fetching, business logic, and state management.
+*   `adapters/`: (Optional) Contains classes for adapting data between different formats (e.g., API responses to application models).
+*   `constants.ts`: (Optional) Stores module-specific constants.
+*   `*.routes.ts`: Defines routing configurations for the module.
+
+### 1.2 Core Modules
+
+*   `shared/`: This module is crucial for housing reusable components, directives, pipes, and services that are used across multiple other modules. It promotes reusability and avoids code duplication.
+*   `layouts/`: Contains components responsible for the overall application layout (e.g., header, sidebar, footer).
+*   `environments/`: Manages environment-specific configurations (e.g., API URLs, reCAPTCHA keys).
+
+## 2. Technologies and Libraries
+
+*   **Angular:** The primary framework for building the single-page application.
+*   **TypeScript:** Used for type-safe and robust code development.
+*   **Angular Material:** A UI component library providing pre-built, high-quality components following Material Design guidelines.
+*   **RxJS:** Used extensively for reactive programming, managing asynchronous operations, and handling events.
+*   **Angular Signals:** Leveraged for modern, reactive state management within components and services.
+*   **OpenLayers (`ol`):** Utilized for mapping functionalities (inferred from `package.json`).
+*   **reCAPTCHA:** Integrated for security purposes, especially in authentication flows.
+
+## 3. Coding Practices
+
+### 3.1 Components
+
+*   **Standalone Components:** Components are preferably standalone (`standalone: true`) to reduce boilerplate and improve tree-shakability.
+*   **Reactive Forms:** `FormBuilder` and `FormGroup` are used for handling forms, enabling robust validation and state management.
+*   **Input Validation:** Angular's built-in `Validators` (e.g., `Validators.required`, `Validators.email`) are used for client-side form validation.
+*   **UI State Management:** `WritableSignal` is used for managing component-specific UI state (e.g., `isLoading`, `errorMessage`, `hidePassword`).
+*   **Lifecycle Hooks:** `ngOnInit` is used for initialization logic, such as loading external scripts or fetching initial data.
+
+### 3.2 Services
+
+*   **Dependency Injection:** Services are injected using either the `inject` function or constructor injection.
+*   **State Management:** Services manage application-wide or module-specific state using Angular Signals (`signal`, `computed`).
+*   **Asynchronous Operations:** RxJS observables are used for all asynchronous operations (e.g., HTTP requests, timers). Operators like `tap`, `finalize`, and `catchError` are commonly used for side effects and error handling.
+*   **Token Management:** Clear and encapsulated methods (`setTokens`, `getTokens`, `clearTokens`) are provided for managing authentication tokens (access and refresh tokens).
+*   **Error Handling:** Services implement error handling for API calls, often returning `EMPTY` or `throwError` observables in case of errors.
+
+### 3.3 TypeScript
+
+*   **Interfaces:** Interfaces are widely used to define the shape of data objects, ensuring type safety throughout the application.
+*   **Enums:** Enums are used for defining a set of related constant values, improving code readability and maintainability.
+*   **Type Safety:** Explicit typing is encouraged for variables, function parameters, and return values.
+
+### 3.4 API Interaction
+
+*   **HttpClient:** Angular's `HttpClient` is used for making HTTP requests to the backend API.
+*   **Environment Variables:** API URLs are configured using environment variables (`environment.apiUrl`) to facilitate easy switching between development, staging, and production environments.
+
+## 4. Naming Conventions
+
+The project adheres to standard Angular and TypeScript naming conventions, promoting consistency and readability.
+
+*   **Files:**
+    *   Components: `feature-name.component.ts`, `feature-name.component.html`, `feature-name.component.css`
+    *   Services: `feature-name.service.ts`
+    *   Interfaces: `entity-name.interface.ts`
+    *   Enums: `enum-name.enum.ts`
+    *   Routes: `feature-name.routes.ts`
+*   **Classes:** PascalCase (e.g., `AuthService`, `LoginFormComponent`).
+*   **Interfaces:** PascalCase, often prefixed with `I` (though not strictly enforced, `AuthResponse` is an example) or simply descriptive (e.g., `UserAuth`).
+*   **Enums:** PascalCase (e.g., `AuthStatus`, `Role`).
+*   **Functions/Methods:** camelCase (e.g., `login`, `checkStatus`, `loadRecaptchaScript`).
+*   **Variables:** camelCase (e.g., `loginForm`, `isLoading`, `accessToken`).
+*   **Private Members:** Private class members are typically prefixed with an underscore (`_`) (e.g., `_authState`, `_storage`).
+*   **Constants:** UPPER_SNAKE_CASE for global constants (e.g., `INITIAL_STATE`, `environment.reCAPTCHA_SiteKey`).
+
+## 5. Security
+
+*   **Token-Based Authentication:** The application uses access and refresh tokens for user authentication, a common and secure practice.
+*   **reCAPTCHA:** Integrated into authentication flows to prevent bot attacks and ensure legitimate user interactions.
+
+This document serves as a living guide for developers contributing to the `propinq-frontend` project. Adhering to these conventions will help maintain a high-quality, scalable, and understandable codebase.

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,22 @@
+# https://angular.dev/tools/cli/deployment#manual-deployment-to-a-remote-server
+
+ARG NODE_VERSION=20.17.0
+
+FROM node:${NODE_VERSION}-alpine AS build
+
+WORKDIR /usr/src/app
+
+# Build context is the repo parent (../ from propinq-infra); lockfile lives under propinq-frontend/
+COPY propinq-frontend/package*.json ./
+RUN npm ci
+COPY propinq-frontend/ .
+RUN npx ng build --configuration production
+
+FROM nginx:alpine
+
+COPY --from=build /usr/src/app/dist/propinq-frontend/browser /usr/share/nginx/html
+COPY propinq-frontend/nginx/default.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/angular.json
+++ b/angular.json
@@ -37,13 +37,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "1.5MB",
+                  "maximumError": "2MB"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "6kB",
+                  "maximumError": "10kB"
                 }
               ],
               "outputHashing": "all"

--- a/docs/PR-PROPINQ-114-frontend.md
+++ b/docs/PR-PROPINQ-114-frontend.md
@@ -1,0 +1,47 @@
+## PROPINQ-114: Flujo de registro y activación por código (frontend)
+
+**Base:** `dev`
+
+Alinea el cliente Angular con los cambios de backend para registro, reenvío y activación de cuenta en producción DigitalOcean.
+
+### Arquitectura del feature
+
+- Rutas de autenticación unificadas bajo `${apiUrl}/api/v1/auth/*`.
+- Activación manual por formulario (email + código de 6 dígitos) reemplaza auto-activación por query `userId` + UUID.
+- Manejo de errores centralizado en `ErrorInterceptor` compatible con RFC 7807 (`detail`).
+
+### Servicios y contratos HTTP
+
+- `AuthService`: login, signup, check-token y refresh-token apuntan a `/api/v1/auth/...`.
+- `UserService.activateUser(email, verificationCode)` → `POST /api/v1/users/activate`.
+- `UserService.resendActivationEmail` mantiene `POST /api/v1/users/resend-activation-email`.
+
+### Páginas y componentes
+
+- `account-activation-page`: formulario con email y código; éxito redirige a login.
+- `verify-email-page`: reenvío con límite local de 3 intentos; navega a `/auth/activate?email=...` sin duplicar toasts de error.
+- Eliminación de snackbars de error locales donde el interceptor global ya notifica.
+
+### Interceptores
+
+- `ErrorInterceptor`: lee `error.error.detail` además de `message` para mostrar mensajes del backend (ej. email duplicado, código inválido).
+
+### Errores solucionados
+
+- POST a `/auth/signup` devolvía 405 desde Nginx/frontend estático.
+- Mensaje genérico "Ocurrió un error inesperado" ante respuestas Problem Details de Spring Boot 3.
+- Alertas duplicadas al reenviar correo (interceptor + snackbar del componente).
+- Loop de verificación por magic link incompatible con la UI de código.
+
+### Archivos impactados
+
+- `src/app/auth/services/auth.service.ts`
+- `src/users/services/user.service.ts`
+- `src/app/shared/interceptors/error.interceptor.ts`
+- `src/app/auth/pages/account-activation-page/*`
+- `src/app/auth/pages/verify-email-page/*`
+
+### Validación
+
+- Pruebas manuales: registro con email nuevo, reenvío de código, activación e inicio de sesión en producción.
+- Pruebas automáticas: pendiente de E2E Cypress en rama de testing.

--- a/docs/PR-PROPINQ-114-frontend.md
+++ b/docs/PR-PROPINQ-114-frontend.md
@@ -1,20 +1,22 @@
-## PROPINQ-114: Flujo de registro y activación por código (frontend)
+## PROPINQ-114: Registro, activación y enrutamiento API (frontend)
 
 **Base:** `dev`
 
-Alinea el cliente Angular con los cambios de backend para registro, reenvío y activación de cuenta en producción DigitalOcean.
+Alinea el cliente Angular con backend en producción DigitalOcean: registro y activación por código, interceptor RFC 7807, y centralización de `apiUrl` con prefijo `/api/v1` para que Nginx enrute las peticiones al backend.
 
 ### Arquitectura del feature
 
-- Rutas de autenticación unificadas bajo `${apiUrl}/api/v1/auth/*`.
+- `environment.apiUrl`: `'/api/v1'` en producción y `'http://localhost:8080/api/v1'` en desarrollo.
+- Todos los servicios concatenan `environment.apiUrl + '/ruta'` sin duplicar el prefijo en cada archivo (~18 servicios).
 - Activación manual por formulario (email + código de 6 dígitos) reemplaza auto-activación por query `userId` + UUID.
 - Manejo de errores centralizado en `ErrorInterceptor` compatible con RFC 7807 (`detail`).
 
 ### Servicios y contratos HTTP
 
-- `AuthService`: login, signup, check-token y refresh-token apuntan a `/api/v1/auth/...`.
-- `UserService.activateUser(email, verificationCode)` → `POST /api/v1/users/activate`.
-- `UserService.resendActivationEmail` mantiene `POST /api/v1/users/resend-activation-email`.
+- `AuthService`: login, signup, check-token y refresh-token bajo `${apiUrl}/auth/...`.
+- `UserService.activateUser(email, verificationCode)` → `POST ${apiUrl}/users/activate`.
+- `UserService.resendActivationEmail` → `POST ${apiUrl}/users/resend-activation-email`.
+- Servicios de dominio (`properties`, `parameters`, `neighborhoods`, `buildings`, etc.) usan rutas relativas sin `/api/v1` hardcodeado.
 
 ### Páginas y componentes
 
@@ -24,24 +26,26 @@ Alinea el cliente Angular con los cambios de backend para registro, reenvío y a
 
 ### Interceptores
 
-- `ErrorInterceptor`: lee `error.error.detail` además de `message` para mostrar mensajes del backend (ej. email duplicado, código inválido).
+- `ErrorInterceptor`: lee `error.error.detail` además de `message`; sin filtrar 401/403 (alineado con producción).
 
 ### Errores solucionados
 
+- Peticiones a `/parameters`, `/properties`, etc. sin `/api/v1` devolvían `index.html` del SPA → "Ocurrió un error inesperado".
 - POST a `/auth/signup` devolvía 405 desde Nginx/frontend estático.
-- Mensaje genérico "Ocurrió un error inesperado" ante respuestas Problem Details de Spring Boot 3.
+- Mensaje genérico ante respuestas Problem Details de Spring Boot 3.
 - Alertas duplicadas al reenviar correo (interceptor + snackbar del componente).
 - Loop de verificación por magic link incompatible con la UI de código.
 
 ### Archivos impactados
 
-- `src/app/auth/services/auth.service.ts`
-- `src/users/services/user.service.ts`
+- `src/environments/environment.ts`, `environment.development.ts`
+- `src/app/auth/services/auth.service.ts`, páginas de activación/verificación
+- `src/users/services/user.service.ts` y servicios de dominio (`properties`, `parameters`, `neighborhoods`, etc.)
 - `src/app/shared/interceptors/error.interceptor.ts`
-- `src/app/auth/pages/account-activation-page/*`
-- `src/app/auth/pages/verify-email-page/*`
+- `Dockerfile.prod`, `nginx/default.conf`, `angular.json` (budgets para build de producción)
 
 ### Validación
 
-- Pruebas manuales: registro con email nuevo, reenvío de código, activación e inicio de sesión en producción.
+- Pruebas manuales: home, listado de propiedades, parámetros y barrios en `propinq.online`.
+- Producción: endpoints críticos responden HTTP 200 vía proxy Nginx.
 - Pruebas automáticas: pendiente de E2E Cypress en rama de testing.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src/app/auth/components/login-form/login-form.component.ts
+++ b/src/app/auth/components/login-form/login-form.component.ts
@@ -10,7 +10,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 import { NotificationService } from '../../../shared/services/notification.service';
-import { environment } from '../../../../environments/environment.development';
+import { environment } from '../../../../environments/environment';
 
 declare var grecaptcha: any;
 

--- a/src/app/auth/pages/account-activation-page/account-activation-page.component.css
+++ b/src/app/auth/pages/account-activation-page/account-activation-page.component.css
@@ -1,86 +1,202 @@
-.activation-bg {
-  min-height: 100vh;
-  min-width: 100vw;
-  background: linear-gradient(135deg, #232b36 0%, #1c2232 100%);
+.activation-page-container {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: row;
+  min-height: 100vh;
+  width: 100vw;
+  padding: 0;
 }
 
-.activation-card {
-  background: #fff;
-  padding: 2.8rem 2.2rem 2.2rem 2.2rem;
-  border-radius: 16px;
-  box-shadow: 0 8px 32px rgba(16,32,40,0.12);
-  max-width: 440px;
-  width: 100%;
-  text-align: center;
+.activation-bg-half {
+  width: 50vw;
+  height: 100vh;
+  background: linear-gradient(135deg, #1a1e2b 0%, #2d3748 50%, #1a1e2b 100%);
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  position: relative;
 }
 
-.activation-icon {
-  margin-bottom: 1.7rem;
+.activation-bg-half::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle at 30% 70%, rgba(79, 172, 254, 0.1) 0%, transparent 50%),
+              radial-gradient(circle at 70% 30%, rgba(139, 92, 246, 0.1) 0%, transparent 50%);
 }
 
-.activation-icon svg {
-  display: block;
+.activation-bg-half img {
+  max-width: 1000px;
+  max-height: 1000px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 8px;
+  z-index: 1;
+  position: relative;
+}
+
+.activation-form-half {
+  width: 50vw;
+  height: 100vh;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 25%, #f1f5f9 50%, #ffffff 75%, #f8fafc 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.activation-form-half::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background:
+    radial-gradient(circle at 20% 80%, rgba(59, 130, 246, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(16, 185, 129, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 40% 40%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+}
+
+.activation-form {
+  width: 100%;
+  max-width: 650px;
+  min-width: 400px;
   margin: 0 auto;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.1),
+              0 0 0 1px rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  padding: 48px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  position: relative;
+  z-index: 1;
 }
 
-h1 {
-  font-size: 2rem;
-  color: #232b36;
-  margin: 0 0 1rem 0;
+.activation-form::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.8) 100%);
+  border-radius: 16px;
+  z-index: -1;
+}
+
+.activation-form h1 {
+  font-size: 32px;
+  color: #1e293b;
+  text-align: center;
+  margin: 0;
   font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .activation-message {
-  color: #454545;
-  font-size: 1.10rem;
-  margin-bottom: 2.2rem;
-  line-height: 1.6;
+  color: #1e293b;
+  margin: 0 0 6px;
+  text-align: center;
+  line-height: 1.45;
 }
 
-.activation-actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
+.input-field {
   width: 100%;
+  color: #1e293b;
 }
 
-.activation-btn {
-  background: #232b36;
-  color: #fff;
-  border: none;
-  border-radius: 999px;
-  padding: 0.75rem 1.6rem;
-  font-size: 1rem;
+.input-field .mat-mdc-form-field {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+}
+
+.activation-button {
+  margin-top: 14px;
+  width: 100%;
+  font-weight: bold;
+  letter-spacing: 1px;
+  padding: 12px 0;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #1e293b 0%, #334155 50%, #1e293b 100%) !important;
+  color: white !important;
+  box-shadow: 0 10px 25px -5px rgba(30, 41, 59, 0.3),
+              0 0 0 1px rgba(30, 41, 59, 0.1);
+  transition: all 0.2s ease;
+}
+
+.activation-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 35px -5px rgba(30, 41, 59, 0.4);
+}
+
+.alt-link {
+  margin-top: 8px;
+  text-align: center;
+  color: #1e293b;
+  text-decoration: none;
+  display: block;
   font-weight: 500;
-  cursor: pointer;
-  transition: background 0.2s;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  transition: color 0.2s ease;
 }
 
-.activation-btn:hover {
-  background: #22a06b;
+.alt-link:hover {
+  color: #0f172a;
 }
 
-.activation-btn.secondary {
-  background: #f4f4f4;
-  color: #232b36;
-  border: 1px solid #d8dbe2;
+mat-progress-spinner {
+  display: block;
+  margin: 0 auto 16px auto;
 }
 
-.activation-btn.secondary:hover {
-  background: #eafbf3;
-  color: #22a06b;
+::ng-deep .mat-mdc-form-field-label {
+  color: #1e293b !important;
+  font-weight: 500;
 }
 
-.material-icons {
-  font-size: 1.2em;
-  vertical-align: middle;
+::ng-deep .mat-mdc-input-element {
+  color: #1e293b !important;
+}
+
+::ng-deep .mdc-text-field--outlined .mdc-floating-label,
+::ng-deep .mdc-text-field--filled .mdc-floating-label {
+  color: #1e293b !important;
+}
+
+::ng-deep .mat-mdc-input-element::placeholder {
+  color: #475569 !important;
+  opacity: 1;
+}
+
+::ng-deep .mat-mdc-form-field-outline {
+  color: #d1d5db !important;
+}
+
+::ng-deep .mat-mdc-form-field-focus-overlay {
+  background-color: rgba(59, 130, 246, 0.05) !important;
+}
+
+@media (max-width: 768px) {
+  .activation-page-container {
+    flex-direction: column;
+  }
+
+  .activation-bg-half,
+  .activation-form-half {
+    width: 100vw;
+    height: 50vh;
+  }
+
+  .activation-form {
+    max-width: 90%;
+    min-width: 0;
+    padding: 32px 24px;
+  }
 }

--- a/src/app/auth/pages/account-activation-page/account-activation-page.component.html
+++ b/src/app/auth/pages/account-activation-page/account-activation-page.component.html
@@ -1,21 +1,43 @@
-<div class="activation-bg">
-  <div class="activation-card">
-<div class="activation-icon">
-  <svg width="72" height="72" viewBox="0 0 72 72" fill="none">
-    <circle cx="36" cy="36" r="36" fill="#EAFBF3"/>
-    <path d="M24 37L33 46L48 30" stroke="#22a06b" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
-  </svg>
-</div>
-    <h1>¡Cuenta Activada!</h1>
-    <p class="activation-message">
-      Tu cuenta ha sido activada exitosamente.<br>
-      Ya puedes cerrar esta página o continuar utilizando la aplicación.
-    </p>
-    <div class="activation-actions">
-      <button class="activation-btn" routerLink="/">Volver al inicio</button>
-      <button class="activation-btn secondary" routerLink="/auth/login">
-        <span class="material-icons">login</span>
-        Iniciar sesión
-      </button>
-    </div>
+<section class="activation-page-container">
+  <div class="activation-bg-half">
+    <img src="PropInq.png" alt="Logo" />
   </div>
+
+  <div class="activation-form-half">
+    <form autocomplete="off" class="activation-form" [formGroup]="activationForm" (ngSubmit)="onActivate()">
+      <h1>Activar cuenta</h1>
+      <p class="activation-message">Completá tu email y el código de verificación que recibiste.</p>
+
+      <mat-form-field appearance="outline" class="input-field">
+        <mat-label>Correo electrónico</mat-label>
+        <input matInput formControlName="email" type="email" autocomplete="email" />
+        @if (activationForm.get('email')?.invalid && activationForm.get('email')?.touched) {
+          <mat-error>Ingresa un correo válido</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="input-field">
+        <mat-label>Código de verificación</mat-label>
+        <input matInput #codeInput formControlName="activationToken" autocomplete="off" />
+        @if (activationForm.get('activationToken')?.invalid && activationForm.get('activationToken')?.touched) {
+          <mat-error>Ingresa el código de verificación</mat-error>
+        }
+      </mat-form-field>
+
+      <div class="activation-actions">
+        @if (isLoading()) {
+          <mat-progress-spinner mode="indeterminate" diameter="30"></mat-progress-spinner>
+        } @else {
+          <button mat-raised-button color="primary" type="submit" class="activation-button" [disabled]="activationForm.invalid || isLoading()">
+            Verificar cuenta
+          </button>
+        }
+      </div>
+
+      <a [routerLink]="'/auth/verify-email'" [queryParams]="{ email: activationForm.get('email')?.value }" class="alt-link">
+        Enviar código a otro correo
+      </a>
+      <a routerLink="/auth/login" class="alt-link">Volver al login</a>
+    </form>
+  </div>
+</section>

--- a/src/app/auth/pages/account-activation-page/account-activation-page.component.ts
+++ b/src/app/auth/pages/account-activation-page/account-activation-page.component.ts
@@ -1,30 +1,96 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, OnDestroy, OnInit, signal } from '@angular/core';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { AfterViewInit, ChangeDetectionStrategy, Component, inject, OnInit, signal, ViewChild } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
+import { CustomSnackbarService } from '../../../shared/services/snackbar.service';
 import { UserService } from '../../../../users/services/user.service';
-import { Subscription } from 'rxjs';
-import { QueryParamsService } from '../../../shared/services/query-params.service';
 
 @Component({
   selector: 'app-account-activation-page',
-  imports: [RouterLink],
+  imports: [
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    RouterLink,
+  ],
   templateUrl: './account-activation-page.component.html',
   styleUrls: ['./account-activation-page.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AccountActivationPageComponent {
+export class AccountActivationPageComponent implements OnInit, AfterViewInit {
   private userService = inject(UserService);
-  private queryParamsService = inject(QueryParamsService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private formBuilder = inject(FormBuilder);
+  private snackbarService = inject(CustomSnackbarService);
 
-  userId = computed(() => this.queryParamsService.queryParams()?.['userId'] || null);
-  activationToken = computed(() => this.queryParamsService.queryParams()?.['activationToken'] || null);
+  @ViewChild('codeInput') codeInput: any;
 
-  constructor() {
-    effect(() => {
-      const userId = this.userId();
-      const activationToken = this.activationToken();
-      if (userId && activationToken) {
-        this.userService.activateUser(userId, activationToken).subscribe();
+  activationForm = this.formBuilder.group({
+    email: ['', [Validators.required, Validators.email]],
+    activationToken: ['', [Validators.required]],
+  });
+
+  isLoading = signal(false);
+
+  ngOnInit() {
+    this.route.queryParams.subscribe((params) => {
+      const email = params['email'] || '';
+      const activationToken = params['activationToken'] || '';
+
+      if (email) {
+        this.activationForm.patchValue({ email });
+      }
+
+      if (activationToken) {
+        this.activationForm.patchValue({ activationToken });
       }
     });
+  }
+
+  ngAfterViewInit() {
+    // Auto-focus on activation code input for better UX
+    if (this.codeInput) {
+      this.codeInput.nativeElement.focus();
+    }
+  }
+
+  onActivate() {
+    if (this.activationForm.invalid || this.isLoading()) {
+      this.activationForm.markAllAsTouched();
+      return;
+    }
+
+    const email = this.activationForm.value.email?.trim();
+    const activationToken = this.activationForm.value.activationToken?.trim();
+
+    if (!email || !activationToken) {
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.userService
+      .activateUser(email, activationToken)
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        next: () => {
+          this.snackbarService.show({
+            message: 'Cuenta activada exitosamente',
+            type: 'success',
+            duration: 5000,
+            position: 'bottom-center',
+          });
+          this.router.navigateByUrl('/auth/login');
+        },
+        error: () => {
+          // El interceptor global ya muestra la notificación de error
+        },
+      });
   }
 }

--- a/src/app/auth/pages/verify-email-page/verify-email-page.component.css
+++ b/src/app/auth/pages/verify-email-page/verify-email-page.component.css
@@ -1,202 +1,202 @@
-.activation-page-container {
+.verify-page-container {
+  display: flex;
+  flex-direction: row;
   min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: linear-gradient(to right , #1a1e2b, #232a3b);
-  padding: 20px;
+  width: 100vw;
+  padding: 0;
 }
 
-.activation-content {
-  background: white;
-  border-radius: 16px;
-  padding: 48px 40px;
-  max-width: 600px;
+.verify-bg-half {
+  width: 50vw;
+  height: 100vh;
+  background: linear-gradient(135deg, #1a1e2b 0%, #2d3748 50%, #1a1e2b 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.verify-bg-half::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle at 30% 70%, rgba(79, 172, 254, 0.1) 0%, transparent 50%),
+              radial-gradient(circle at 70% 30%, rgba(139, 92, 246, 0.1) 0%, transparent 50%);
+}
+
+.verify-bg-half img {
+  max-width: 1000px;
+  max-height: 1000px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 8px;
+  z-index: 1;
+  position: relative;
+}
+
+.verify-form-half {
+  width: 50vw;
+  height: 100vh;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 25%, #f1f5f9 50%, #ffffff 75%, #f8fafc 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.verify-form-half::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background:
+    radial-gradient(circle at 20% 80%, rgba(59, 130, 246, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(16, 185, 129, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 40% 40%, rgba(139, 92, 246, 0.03) 0%, transparent 50%);
+}
+
+.verify-form {
   width: 100%;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
-  text-align: center;
-  animation: slideUp 0.6s ease-out;
+  max-width: 650px;
+  min-width: 400px;
+  margin: 0 auto;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.1),
+              0 0 0 1px rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  padding: 48px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  position: relative;
+  z-index: 1;
 }
 
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.verify-form::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.8) 100%);
+  border-radius: 16px;
+  z-index: -1;
 }
 
-.success-icon {
-  margin-bottom: 24px;
-}
-
-.check-icon {
-  font-size: 72px;
-  width: 72px;
-  height: 72px;
-  color: #4caf50;
-  background: #e8f5e8;
-  border-radius: 50%;
-  padding: 16px;
-  animation: bounceIn 0.8s ease-out;
-}
-
-@keyframes bounceIn {
-  0% { transform: scale(0.3); opacity: 0; }
-  50% { transform: scale(1.05); }
-  70% { transform: scale(0.9); }
-  100% { transform: scale(1); opacity: 1; }
-}
-
-.activation-title {
+.verify-form h1 {
   font-size: 32px;
-  font-weight: 600;
-  color: #333;
-  margin-bottom: 24px;
-  letter-spacing: -0.5px;
+  color: #1e293b;
+  text-align: center;
+  margin: 0;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
-.activation-message {
-  margin-bottom: 32px;
+.description {
+  color: #1e293b;
+  margin: 0 0 6px;
+  text-align: center;
+  line-height: 1.45;
 }
 
-.main-message {
-  font-size: 18px;
-  color: #555;
-  margin-bottom: 12px;
-  font-weight: 500;
+.input-field {
+  width: 100%;
+  color: #1e293b;
 }
 
-.sub-message {
-  font-size: 16px;
-  color: #777;
-  line-height: 1.6;
-  margin-bottom: 0;
+.input-field .mat-mdc-form-field {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
 }
 
-.info-box {
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
+.verify-button {
+  margin-top: 14px;
+  width: 100%;
+  font-weight: bold;
+  letter-spacing: 1px;
+  padding: 12px 0;
   border-radius: 12px;
-  padding: 24px;
-  margin-bottom: 32px;
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
-  text-align: left;
+  background: linear-gradient(135deg, #1e293b 0%, #334155 50%, #1e293b 100%) !important;
+  color: white !important;
+  box-shadow: 0 10px 25px -5px rgba(30, 41, 59, 0.3),
+              0 0 0 1px rgba(30, 41, 59, 0.1);
+  transition: all 0.2s ease;
 }
 
-.info-icon {
-  color: #2196f3;
-  font-size: 24px;
-  margin-top: 2px;
-  flex-shrink: 0;
+.verify-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 35px -5px rgba(30, 41, 59, 0.4);
 }
 
-.info-content p {
-  margin: 0 0 12px 0;
-  color: #333;
-  font-weight: 600;
-}
-
-.info-content ul {
-  margin: 0;
-  padding-left: 20px;
-  color: #666;
-}
-
-.info-content li {
-  margin-bottom: 8px;
-  line-height: 1.5;
-}
-
-.action-buttons {
-  display: flex;
-  gap: 16px;
-  justify-content: center;
-  margin-bottom: 32px;
-  flex-wrap: wrap;
-}
-
-.home-button, .login-button {
-  min-width: 160px;
-  height: 48px;
+.alt-link {
+  margin-top: 16px;
+  text-align: center;
+  color: #1e293b;
+  text-decoration: none;
+  display: block;
   font-weight: 500;
-  border-radius: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
+  transition: color 0.2s ease;
 }
 
-.home-button {
-  background: linear-gradient(to right , #1a1e2b, #232a3b);
-  color: rgb(255, 255, 255);
-  border: none;
-  cursor: pointer;
+.alt-link:hover {
+  color: #0f172a;
 }
 
-.home-button:hover {
-  background: linear-gradient(to right, #555454, #53565d);
+mat-progress-spinner {
+  display: block;
+  margin: 0 auto 16px auto;
 }
 
-.login-button {
-  color: linear-gradient(to right , #1a1e2b, #232a3b);
-  border-color: none;
-  cursor: pointer;
-}
-
-.resend-section {
-  padding-top: 24px;
-  border-top: 1px solid #e9ecef;
-}
-
-.resend-text {
-  color: #666;
-  margin: 0;
-  font-size: 14px;
-}
-
-.resend-link {
-  color: #2196f3 !important;
-  text-decoration: underline;
+::ng-deep .mat-mdc-form-field-label {
+  color: #1e293b !important;
   font-weight: 500;
-  cursor: pointer;
-  border: none;
-  background-color: transparent;
 }
 
-.resend-link:hover {
-  background: transparent !important;
-  color: #1976d2 !important;
+::ng-deep .mat-mdc-input-element {
+  color: #1e293b !important;
 }
 
-/* ✅ Responsive */
+::ng-deep .mdc-text-field--outlined .mdc-floating-label,
+::ng-deep .mdc-text-field--filled .mdc-floating-label {
+  color: #1e293b !important;
+}
+
+::ng-deep .mat-mdc-input-element::placeholder {
+  color: #475569 !important;
+  opacity: 1;
+}
+
+::ng-deep .mat-mdc-form-field-outline {
+  color: #d1d5db !important;
+}
+
+::ng-deep .mat-mdc-form-field-focus-overlay {
+  background-color: rgba(59, 130, 246, 0.05) !important;
+}
+
 @media (max-width: 768px) {
-  .activation-content {
+  .verify-page-container {
+    flex-direction: column;
+  }
+
+  .verify-bg-half,
+  .verify-form-half {
+    width: 100vw;
+    height: 50vh;
+  }
+
+  .verify-form {
+    max-width: 90%;
+    min-width: 0;
     padding: 32px 24px;
-    margin: 20px;
-  }
-
-  .activation-title {
-    font-size: 28px;
-  }
-
-  .action-buttons {
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .home-button, .login-button {
-    width: 100%;
-    max-width: 280px;
-  }
-
-  .info-box {
-    flex-direction: column;
-    text-align: center;
   }
 }

--- a/src/app/auth/pages/verify-email-page/verify-email-page.component.html
+++ b/src/app/auth/pages/verify-email-page/verify-email-page.component.html
@@ -1,60 +1,32 @@
-<section class="activation-page-container">
-  <div class="activation-content">
-    <div class="success-icon">
-      <mat-icon class="check-icon">mark_email_read</mat-icon>
-    </div>
+<section class="verify-page-container">
+  <div class="verify-bg-half">
+    <img src="PropInq.png" alt="Logo" />
+  </div>
 
-    <h1 class="activation-title">¡Registro Exitoso!</h1>
+  <div class="verify-form-half">
+    <form autocomplete="off" [formGroup]="resendForm" (ngSubmit)="onResendEmail()" class="verify-form">
+      <h1>Verifica tu email</h1>
+      <p class="description">Ingresa tu correo y te enviaremos el codigo para activar tu cuenta.</p>
 
-    <div class="activation-message">
-      <p class="main-message">
-        Se ha enviado un correo electrónico de verificación a tu dirección de email.
-      </p>
-      <p class="sub-message">
-        Por favor, revisa tu bandeja de entrada y haz clic en el enlace de verificación
-        para activar tu cuenta.
-      </p>
-    </div>
+      <mat-form-field class="input-field" appearance="outline">
+        <mat-label>Correo electrónico</mat-label>
+        <input matInput formControlName="email" type="email" autocomplete="email" />
+        @if (resendForm.get('email')?.invalid && resendForm.get('email')?.touched) {
+          <mat-error>Ingresa un correo válido</mat-error>
+        }
+      </mat-form-field>
 
-    <div class="info-box">
-      <mat-icon class="info-icon">info</mat-icon>
-      <div class="info-content">
-        <p><strong>¿No encuentras el correo?</strong></p>
-        <ul>
-          <li>Revisa tu carpeta de spam o correo no deseado</li>
-          <li>Asegúrate de que la dirección de email sea correcta</li>
-          <li>El enlace de verificación expira en 24 horas</li>
-        </ul>
+      <div class="verify-actions">
+        @if (isLoading()) {
+          <mat-progress-spinner mode="indeterminate" diameter="30"></mat-progress-spinner>
+        } @else {
+          <button mat-raised-button color="primary" type="submit" class="verify-button" [disabled]="resendForm.invalid || isLoading()">
+            Enviar código
+          </button>
+        }
       </div>
-    </div>
 
-    <div class="action-buttons">
-      <button
-        mat-raised-button
-        color="primary"
-        routerLink="/"
-        class="home-button">
-        <mat-icon>home</mat-icon>
-        Volver a Inicio
-      </button>
-
-      <button
-        mat-stroked-button
-        color="accent"
-        routerLink="/auth/login"
-        class="login-button">
-        <mat-icon>login</mat-icon>
-        Ir a Iniciar Sesión
-      </button>
-    </div>
-
-    <div class="resend-section">
-      <p class="resend-text">
-        ¿No recibiste el correo?
-        <button mat-button color="primary" class="resend-link" (click)="onResendEmail()">
-          Reenviar correo de verificación
-        </button>
-      </p>
-    </div>
+      <a routerLink="/auth/login" class="alt-link">Volver al login</a>
+    </form>
   </div>
 </section>

--- a/src/app/auth/pages/verify-email-page/verify-email-page.component.ts
+++ b/src/app/auth/pages/verify-email-page/verify-email-page.component.ts
@@ -1,21 +1,30 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  effect,
   inject,
   OnInit,
   signal,
 } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
-import { MatIcon } from '@angular/material/icon';
-import { ActivatedRoute, RouterLink } from '@angular/router';
-import { EMPTY } from 'rxjs';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { finalize } from 'rxjs';
 import { CustomSnackbarService } from '../../../shared/services/snackbar.service';
 import { UserService } from '../../../../users/services/user.service';
 
 @Component({
   selector: 'app-verify-email-page',
-  imports: [MatIcon, RouterLink],
+  imports: [
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    RouterLink,
+  ],
   templateUrl: './verify-email-page.component.html',
   styleUrls: ['./verify-email-page.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,39 +32,35 @@ import { UserService } from '../../../../users/services/user.service';
 export class VerifyEmailPageComponent implements OnInit {
   private userService = inject(UserService);
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private formBuilder = inject(FormBuilder);
   private snackbarService = inject(CustomSnackbarService);
 
-  maxResends = signal(3);
-  resendCount = signal(0);
-  email = signal<string>('');
-  ngOnInit() {
-    this.route.queryParams.subscribe((params) => {
-      this.email.set(params['email'] || '');
-    });
-  }
-  private executeResend = signal<string | null>(null);
-
-  private resendResource = rxResource({
-    request: () => this.executeResend(),
-    loader: ({ request }) => {
-      if (!request) return EMPTY;
-      return this.userService.resendActivationEmail(request);
-    },
+  resendForm = this.formBuilder.group({
+    email: ['', [Validators.required, Validators.email]],
   });
 
+  isLoading = signal(false);
+  resendCount = signal(0);
+  maxResends = signal(3);
+
+  ngOnInit() {
+    this.route.queryParams.subscribe((params) => {
+      const email = params['email'] || '';
+
+      if (email) {
+        this.resendForm.patchValue({ email });
+      }
+    });
+  }
+
   onResendEmail() {
-    this.resendCount.update((count) => count + 1);
-    if (!this.email()) {
-      this.snackbarService.show({
-        message: 'No se pudo obtener el email registrado',
-        type: 'error',
-        duration: 5000,
-        position: 'bottom-center',
-      });
+    if (this.resendForm.invalid) {
+      this.resendForm.markAllAsTouched();
       return;
     }
 
-    if (this.userService.isLoading()) {
+    if (this.isLoading()) {
       return;
     }
 
@@ -69,23 +74,38 @@ export class VerifyEmailPageComponent implements OnInit {
       return;
     }
 
-    this.executeResend.set(this.email());
-  }
+    const email = this.resendForm.value.email?.trim();
+    if (!email) {
+      this.snackbarService.show({
+        message: 'No se pudo obtener el email registrado',
+        type: 'error',
+        duration: 5000,
+        position: 'bottom-center',
+      });
+      return;
+    }
 
-  constructor() {
-    effect(() => {
-      const result = this.resendResource.value();
-      const request = this.executeResend();
+    this.isLoading.set(true);
+    this.resendCount.update((count) => count + 1);
+    this.userService
+      .resendActivationEmail(email)
+      .pipe(finalize(() => this.isLoading.set(false)))
+      .subscribe({
+        next: () => {
+          this.snackbarService.show({
+            message: 'Código enviado correctamente',
+            type: 'success',
+            duration: 5000,
+            position: 'bottom-center',
+          });
 
-      if (request && result !== undefined) {
-        this.snackbarService.show({
-          message: 'Email de verificación reenviado correctamente',
-          type: 'success',
-          duration: 5000,
-          position: 'bottom-center',
-        });
-        this.executeResend.set(null);
-      }
-    });
+          this.router.navigate(['/auth/activate'], {
+            queryParams: { email },
+          });
+        },
+        error: (error) => {
+          console.error('Error reenviando email:', error);
+        },
+      });
   }
 }

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -48,7 +48,7 @@ export class AuthService {
 
   login(credentials: LoginRequest): Observable<AuthResponse> {
     return this._http
-      .post<AuthResponse>(`${environment.apiUrl}/api/v1/auth/login`, credentials)
+      .post<AuthResponse>(`${environment.apiUrl}/auth/login`, credentials)
       .pipe(
         tap((response) => {
           const { accessToken, refreshToken, user } = response;
@@ -66,7 +66,7 @@ export class AuthService {
   checkStatus(): Observable<UserAuth | null> {
     const accessToken = this._storage.get<string>('accessToken');
     if (!accessToken) return of(null);
-    return this._http.post<UserAuth>(`${environment.apiUrl}/api/v1/auth/check-token`, {
+    return this._http.post<UserAuth>(`${environment.apiUrl}/auth/check-token`, {
       accessToken,
     });
   }
@@ -106,7 +106,7 @@ export class AuthService {
 
     return this.http
       .post<{ success: boolean; status: number }>(
-        `${environment.apiUrl}/api/v1/auth/signup`,
+        `${environment.apiUrl}/auth/signup`,
         {
           dni: signupRequest.dni,
           firstName: signupRequest.firstName,
@@ -129,7 +129,7 @@ export class AuthService {
       return throwError(() => new Error('Refresh token no disponible'));
     }
     return this._http
-      .post<AuthResponse>(`${environment.apiUrl}/api/v1/auth/refresh-token`, {
+      .post<AuthResponse>(`${environment.apiUrl}/auth/refresh-token`, {
         refreshToken,
       })
       .pipe(

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -48,7 +48,7 @@ export class AuthService {
 
   login(credentials: LoginRequest): Observable<AuthResponse> {
     return this._http
-      .post<AuthResponse>(`${environment.apiUrl}/auth/login`, credentials)
+      .post<AuthResponse>(`${environment.apiUrl}/api/v1/auth/login`, credentials)
       .pipe(
         tap((response) => {
           const { accessToken, refreshToken, user } = response;
@@ -66,7 +66,7 @@ export class AuthService {
   checkStatus(): Observable<UserAuth | null> {
     const accessToken = this._storage.get<string>('accessToken');
     if (!accessToken) return of(null);
-    return this._http.post<UserAuth>(`${environment.apiUrl}/auth/check-token`, {
+    return this._http.post<UserAuth>(`${environment.apiUrl}/api/v1/auth/check-token`, {
       accessToken,
     });
   }
@@ -106,7 +106,7 @@ export class AuthService {
 
     return this.http
       .post<{ success: boolean; status: number }>(
-        `${environment.apiUrl}/auth/signup`,
+        `${environment.apiUrl}/api/v1/auth/signup`,
         {
           dni: signupRequest.dni,
           firstName: signupRequest.firstName,
@@ -129,7 +129,7 @@ export class AuthService {
       return throwError(() => new Error('Refresh token no disponible'));
     }
     return this._http
-      .post<AuthResponse>(`${environment.apiUrl}/auth/refresh-token`, {
+      .post<AuthResponse>(`${environment.apiUrl}/api/v1/auth/refresh-token`, {
         refreshToken,
       })
       .pipe(

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { computed, inject, Injectable, signal } from '@angular/core';
 import { EMPTY, finalize, Observable, of, tap, throwError } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 import { ClientStorageService } from '../../shared/services/client-storage.service.abstract';
 import { AuthStatus } from '../enums/auth-status.enum';
 import { AuthResponse } from '../interfaces/auth-response.interface';

--- a/src/app/buildings/buildings.service.ts
+++ b/src/app/buildings/buildings.service.ts
@@ -14,7 +14,7 @@ import { BuildingDetailsPage } from './interfaces/buildings-details-page.interfa
 @Injectable({ providedIn: 'root' })
 export class BuildingsService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/buildings`;
+  private _baseUrl = `${environment.apiUrl}/buildings`;
 
   createBuilding(buildingRequest: BuildingRequest) {
     const formData = new FormData();
@@ -50,14 +50,14 @@ export class BuildingsService {
       return throwError(() => new Error('Invalid buildingQueried: null'));
     }
     return this._http.get<BuildingDetails>(
-      `${environment.apiUrl}/api/v1/buildings/${buildingQueried}`,
+      `${environment.apiUrl}/buildings/${buildingQueried}`,
     );
   }
 
   getBuildingsDetails(page = 0, pageSize = 6): Observable<BuildingDetailsPage> {
     return this._http
       .get<BuildingDetailsPage>(
-        `${environment.apiUrl}/api/v1/buildings/details`,
+        `${environment.apiUrl}/buildings/details`,
         {
           params: { page, size: pageSize },
         },

--- a/src/app/buildings/buildings.service.ts
+++ b/src/app/buildings/buildings.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { map, Observable, throwError } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { PropertyDetails } from '../properties/interfaces/property-details.interface';
 import { PropertyFilterRequest } from '../properties/interfaces/property-filter.request';
 import { buildFilterHttpParams } from '../shared/utilities/http-params.builder';

--- a/src/app/buildings/services/favorite.service.ts
+++ b/src/app/buildings/services/favorite.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class FavoriteService {
-  private apiUrl = `${environment.apiUrl}/api/v1/favorites`;
+  private apiUrl = `${environment.apiUrl}/favorites`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/buildings/services/favorite.service.ts
+++ b/src/app/buildings/services/favorite.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { FavoriteRequest, FavoriteResponse } from '../interfaces/favorite.interface';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class FavoriteService {

--- a/src/app/contacts/contacts.service.ts
+++ b/src/app/contacts/contacts.service.ts
@@ -12,7 +12,7 @@ import { RejectContactRequest } from './interfaces/reject-contact-request.interf
 @Injectable({ providedIn: 'root' })
 export class ContactsService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/contacts`;
+  private _baseUrl = `${environment.apiUrl}/contacts`;
 
   getTenantContactsDetails(page = 0, size = 6): Observable<ContactDetailsPage> {
     return this._http.get<ContactDetailsPage>(`${this._baseUrl}/tenant`, {

--- a/src/app/contacts/contacts.service.ts
+++ b/src/app/contacts/contacts.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { AnswerContactRequest } from './interfaces/answer-contact-request.interface';
 import { ContactDetailsPage } from './interfaces/contact-details-page.interface';
 import { ContactDetails } from './interfaces/contact-details.interface';

--- a/src/app/favorites/services/favorite-service.ts
+++ b/src/app/favorites/services/favorite-service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 import {
   FavoriteEntityPage,
   FavoriteResponse,

--- a/src/app/favorites/services/favorite-service.ts
+++ b/src/app/favorites/services/favorite-service.ts
@@ -9,7 +9,7 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class FavoriteService {
-  private apiUrl = `${environment.apiUrl}/api/v1/favorites`;
+  private apiUrl = `${environment.apiUrl}/favorites`;
   private http = inject(HttpClient);
 
   getFavoriteBuildings(

--- a/src/app/localities/services/locality.service.ts
+++ b/src/app/localities/services/locality.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 import { LocalityRequest, LocalityResponse } from '../interfaces/locality.interface';
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/localities/services/locality.service.ts
+++ b/src/app/localities/services/locality.service.ts
@@ -7,7 +7,7 @@ import { LocalityRequest, LocalityResponse } from '../interfaces/locality.interf
 @Injectable({ providedIn: 'root' })
 export class LocalityService {
   private http = inject(HttpClient);
-  private readonly baseUrl = `${environment.apiUrl}/api/v1/localities`;
+  private readonly baseUrl = `${environment.apiUrl}/localities`;
 
   getLocalities(): Observable<LocalityResponse[]> {
     return this.http.get<LocalityResponse[]>(`${this.baseUrl}`);

--- a/src/app/maps/services/address.service.ts
+++ b/src/app/maps/services/address.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { catchError, map, Observable, of, tap } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 import { NotificationService } from '../../shared/services/notification.service';
 import { Address } from '../adapters/address.adapter';
 import { MapCoordinate } from '../interfaces/map-coordinate.interface';

--- a/src/app/maps/services/poi.service.ts
+++ b/src/app/maps/services/poi.service.ts
@@ -10,7 +10,7 @@ import { transformExtent } from 'ol/proj';
 @Injectable({ providedIn: 'root' })
 export class PoiService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/pois`;
+  private _baseUrl = `${environment.apiUrl}/pois`;
 
   getPoisWithin(query: PoiWithinQuery) {
     let params = new HttpParams()

--- a/src/app/maps/services/poi.service.ts
+++ b/src/app/maps/services/poi.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { inject, Injectable } from "@angular/core";
-import { environment } from "../../../environments/environment.development";
+import { environment } from "../../../environments/environment";
 import { PoiViewportResult } from "../interfaces/poi-viewport-result.interface";
 import { PoiWithinQuery } from "../interfaces/poi-within-request";
 import { PoiType } from "../interfaces/poi-type.interface";

--- a/src/app/neighborhoods/services/neighborhood.service.ts
+++ b/src/app/neighborhoods/services/neighborhood.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 import { NeighborhoodRequest, NeighborhoodResponse } from '../interfaces/neighborhood.interface';
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/neighborhoods/services/neighborhood.service.ts
+++ b/src/app/neighborhoods/services/neighborhood.service.ts
@@ -7,7 +7,7 @@ import { NeighborhoodRequest, NeighborhoodResponse } from '../interfaces/neighbo
 @Injectable({ providedIn: 'root' })
 export class NeighborhoodService {
   private http = inject(HttpClient);
-  private readonly baseUrl = `${environment.apiUrl}/neighborhoods`;
+  private readonly baseUrl = `${environment.apiUrl}/api/v1/neighborhoods`;
 
   getNeighborhoods(): Observable<NeighborhoodResponse[]> {
     return this.http.get<NeighborhoodResponse[]>(`${this.baseUrl}`);

--- a/src/app/neighborhoods/services/neighborhood.service.ts
+++ b/src/app/neighborhoods/services/neighborhood.service.ts
@@ -7,7 +7,7 @@ import { NeighborhoodRequest, NeighborhoodResponse } from '../interfaces/neighbo
 @Injectable({ providedIn: 'root' })
 export class NeighborhoodService {
   private http = inject(HttpClient);
-  private readonly baseUrl = `${environment.apiUrl}/api/v1/neighborhoods`;
+  private readonly baseUrl = `${environment.apiUrl}/neighborhoods`;
 
   getNeighborhoods(): Observable<NeighborhoodResponse[]> {
     return this.http.get<NeighborhoodResponse[]>(`${this.baseUrl}`);

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -9,7 +9,7 @@ import { NotificationResponse } from './interfaces/notification-response.interfa
 @Injectable({ providedIn: 'root' })
 export class NotificationsService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/notifications`;
+  private _baseUrl = `${environment.apiUrl}/notifications`;
   private _authService = inject(AuthService);
 
   loggedUserNotifications = signal<NotificationResponse[]>([]);

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { effect, inject, Injectable, signal } from '@angular/core';
 import { tap } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { AuthService } from '../auth/services/auth.service';
 import { LargePage } from '../shared/interfaces/page.interface';
 import { NotificationResponse } from './interfaces/notification-response.interface';

--- a/src/app/parameters/parameters.service.ts
+++ b/src/app/parameters/parameters.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class ParametersService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/parameters`;
+  private _baseUrl = `${environment.apiUrl}/parameters`;
 
   maxPrice(): Observable<number> {
     return this._http.get<number>(`${this._baseUrl}/max-price`);

--- a/src/app/parameters/parameters.service.ts
+++ b/src/app/parameters/parameters.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class ParametersService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/parameters`;
+  private _baseUrl = `${environment.apiUrl}/api/v1/parameters`;
 
   maxPrice(): Observable<number> {
     return this._http.get<number>(`${this._baseUrl}/max-price`);

--- a/src/app/parameters/parameters.service.ts
+++ b/src/app/parameters/parameters.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class ParametersService {

--- a/src/app/properties/properties.service.ts
+++ b/src/app/properties/properties.service.ts
@@ -13,7 +13,7 @@ import { UpdatePropertyRequest } from './interfaces/update-property-request.inte
 @Injectable({ providedIn: 'root' })
 export class PropertiesService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/properties`;
+  private _baseUrl = `${environment.apiUrl}/properties`;
 
   getProperties(filter?: PropertyFilterRequest | null): Observable<Property[]> {
     if (filter === null) {
@@ -21,7 +21,7 @@ export class PropertiesService {
     }
     const params = buildFilterHttpParams(filter ?? undefined);
     return this._http.get<Property[]>(
-      `${environment.apiUrl}/api/v1/properties`,
+      `${environment.apiUrl}/properties`,
       { params },
     );
   }
@@ -34,7 +34,7 @@ export class PropertiesService {
     }
 
     return this._http.get<PropertyDetails>(
-      `${environment.apiUrl}/api/v1/properties/${propertyQueried}`,
+      `${environment.apiUrl}/properties/${propertyQueried}`,
     );
   }
 
@@ -44,7 +44,7 @@ export class PropertiesService {
   ): Observable<PropertyDetailsPage> {
     return this._http
       .get<PropertyDetailsPage>(
-        `${environment.apiUrl}/api/v1/properties/details`,
+        `${environment.apiUrl}/properties/details`,
         {
           params: { page, size: pageSize },
         },
@@ -88,7 +88,7 @@ export class PropertiesService {
     radiusKm: number,
   ): Observable<Property[]> {
     return this._http.get<Property[]>(
-      `${environment.apiUrl}/api/v1/properties/nearby`,
+      `${environment.apiUrl}/properties/nearby`,
       {
         params: {
           latitude: latitude,
@@ -116,7 +116,7 @@ export class PropertiesService {
     if (limit != null) params = params.set('limit', limit);
 
     return this._http.get<Property[]>(
-      `${environment.apiUrl}/api/v1/properties/nearby/poi`,
+      `${environment.apiUrl}/properties/nearby/poi`,
       { params },
     );
   }

--- a/src/app/properties/properties.service.ts
+++ b/src/app/properties/properties.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { map, Observable, throwError } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { buildFilterHttpParams } from '../shared/utilities/http-params.builder';
 import { CreatePropertyRequest } from './interfaces/create-property-request.interface';
 import { PropertyDetailsPage } from './interfaces/property-details-page.interface';

--- a/src/app/property-types/services/property-type.service.ts
+++ b/src/app/property-types/services/property-type.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 import { PropertyTypeResponse, PropertyTypeRequest } from '../interfaces/property-type.interface';
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/property-types/services/property-type.service.ts
+++ b/src/app/property-types/services/property-type.service.ts
@@ -7,7 +7,7 @@ import { PropertyTypeResponse, PropertyTypeRequest } from '../interfaces/propert
 @Injectable({ providedIn: 'root' })
 export class PropertyTypeService {
   private http = inject(HttpClient);
-  private readonly baseUrl = `${environment.apiUrl}/api/v1/propertyTypes`;
+  private readonly baseUrl = `${environment.apiUrl}/propertyTypes`;
 
   getPropertyTypes(): Observable<PropertyTypeResponse[]> {
     return this.http.get<PropertyTypeResponse[]>(`${this.baseUrl}/all`);

--- a/src/app/property-types/services/property-type.service.ts
+++ b/src/app/property-types/services/property-type.service.ts
@@ -7,7 +7,7 @@ import { PropertyTypeResponse, PropertyTypeRequest } from '../interfaces/propert
 @Injectable({ providedIn: 'root' })
 export class PropertyTypeService {
   private http = inject(HttpClient);
-  private readonly baseUrl = `${environment.apiUrl}/propertyTypes`;
+  private readonly baseUrl = `${environment.apiUrl}/api/v1/propertyTypes`;
 
   getPropertyTypes(): Observable<PropertyTypeResponse[]> {
     return this.http.get<PropertyTypeResponse[]>(`${this.baseUrl}/all`);

--- a/src/app/provinces/services/province.service.ts
+++ b/src/app/provinces/services/province.service.ts
@@ -7,7 +7,7 @@ import { ProvinceResponse } from '../interfaces/province.interface';
 @Injectable({ providedIn: 'root' })
 export class ProvinceService {
   private http = inject(HttpClient);
-  private readonly baseUrl = `${environment.apiUrl}/api/v1/provinces`;
+  private readonly baseUrl = `${environment.apiUrl}/provinces`;
 
   getProvinces(): Observable<ProvinceResponse[]> {
     return this.http.get<ProvinceResponse[]>(this.baseUrl);

--- a/src/app/provinces/services/province.service.ts
+++ b/src/app/provinces/services/province.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 import { ProvinceResponse } from '../interfaces/province.interface';
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/rents/rents.service.ts
+++ b/src/app/rents/rents.service.ts
@@ -31,7 +31,7 @@ const projections = [
 @Injectable({ providedIn: 'root' })
 export class RentService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/rents`;
+  private _baseUrl = `${environment.apiUrl}/rents`;
 
   saveRent(
     rentRequest: CreateRentRequest,

--- a/src/app/rents/rents.service.ts
+++ b/src/app/rents/rents.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { LargePage } from '../shared/interfaces/page.interface';
 import { CancelRentRequest } from './interfaces/cancel-rent.interface';
 import { RentDocumentRequest } from './interfaces/create-document.interface';

--- a/src/app/shared/interceptors/auth.interceptor.ts
+++ b/src/app/shared/interceptors/auth.interceptor.ts
@@ -8,7 +8,7 @@ import {
 import { Injectable, Injector } from '@angular/core';
 import { catchError, Observable, switchMap, throwError } from 'rxjs';
 import { AuthService } from '../../auth/services/auth.service';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 
 
 @Injectable()

--- a/src/app/shared/interceptors/error.interceptor.ts
+++ b/src/app/shared/interceptors/error.interceptor.ts
@@ -23,9 +23,7 @@ export class ErrorInterceptor implements HttpInterceptor {
           error.error?.message ||
           error.error?.detail ||
           'Ocurrió un error inesperado. Contacte a un administrador.';
-        if (error.status !== 401 && error.status !== 403) {
-          this._injector.get(NotificationService).error(errorMessage, 3000);
-        }
+        this._injector.get(NotificationService).error(errorMessage, 3000);
         return throwError(() => error);
       }),
     );

--- a/src/app/shared/interceptors/error.interceptor.ts
+++ b/src/app/shared/interceptors/error.interceptor.ts
@@ -21,11 +21,12 @@ export class ErrorInterceptor implements HttpInterceptor {
       catchError((error: HttpErrorResponse) => {
         const errorMessage =
           error.error?.message ||
+          error.error?.detail ||
           'Ocurrió un error inesperado. Contacte a un administrador.';
         if (error.status !== 401 && error.status !== 403) {
           this._injector.get(NotificationService).error(errorMessage, 3000);
         }
-        return throwError(() => new Error(errorMessage));
+        return throwError(() => error);
       }),
     );
   }

--- a/src/app/shared/services/reports-embed.service.ts
+++ b/src/app/shared/services/reports-embed.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class ReportsEmbedService {
 
-  private _baseUrl = `${environment.apiUrl}/api/v1/reports`;
+  private _baseUrl = `${environment.apiUrl}/reports`;
 
   private _http = inject(HttpClient);
 

--- a/src/app/shared/services/reports-embed.service.ts
+++ b/src/app/shared/services/reports-embed.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../../../environments/environment.development';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class ReportsEmbedService {

--- a/src/app/users/user-profiles.service.ts
+++ b/src/app/users/user-profiles.service.ts
@@ -8,7 +8,7 @@ import { LargePage } from '../shared/interfaces/page.interface';
 @Injectable({ providedIn: 'root' })
 export class UserProfileService {
   private _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/user-profiles`;
+  private _baseUrl = `${environment.apiUrl}/user-profiles`;
 
   saveOwnerProfileRequest(): Observable<any> {
     return this._http.post(

--- a/src/app/users/user-profiles.service.ts
+++ b/src/app/users/user-profiles.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { ProfileChange } from '../auth/interfaces/user-auth.interface';
 import { LargePage } from '../shared/interfaces/page.interface';
 

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '../../environments/environment.development';
+import { environment } from '../../environments/environment';
 import { UpdateUserRequest } from './interfaces/update-user-request';
 import { UserResponse } from './interfaces/user-response';
 

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -8,7 +8,7 @@ import { UserResponse } from './interfaces/user-response';
 @Injectable({ providedIn: 'root' })
 export class UsersService {
   private readonly _http = inject(HttpClient);
-  private _baseUrl = `${environment.apiUrl}/api/v1/users`;
+  private _baseUrl = `${environment.apiUrl}/users`;
 
   getUserProfile(userId: string): Observable<UserResponse> {
     return this._http.get<UserResponse>(`${this._baseUrl}/${userId}`);

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -2,6 +2,6 @@ export const environment = {
   production: false,
   addressesUrl: 'https://nominatim.openstreetmap.org',
   markerIconUrl: 'https://openlayers.org/en/latest/examples/data/icon.png',
-  apiUrl: 'http://localhost:8080',
+  apiUrl: 'http://localhost:8080/api/v1',
   reCAPTCHA_SiteKey: '6LdbPUQsAAAAAClNS4JkyqHq1Jl2I2sszAEpGb0y',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,7 @@
 export const environment = {
   production: true,
+  addressesUrl: 'https://nominatim.openstreetmap.org',
+  markerIconUrl: 'https://openlayers.org/en/latest/examples/data/icon.png',
+  apiUrl: '',
+  reCAPTCHA_SiteKey: '6LdbPUQsAAAAAClNS4JkyqHq1Jl2I2sszAEpGb0y',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,6 +2,6 @@ export const environment = {
   production: true,
   addressesUrl: 'https://nominatim.openstreetmap.org',
   markerIconUrl: 'https://openlayers.org/en/latest/examples/data/icon.png',
-  apiUrl: '',
+  apiUrl: '/api/v1',
   reCAPTCHA_SiteKey: '6LdbPUQsAAAAAClNS4JkyqHq1Jl2I2sszAEpGb0y',
 };

--- a/src/users/services/user.service.ts
+++ b/src/users/services/user.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from "@angular/common/http";
 import { inject, Injectable, signal } from "@angular/core";
 import { EMPTY, Observable, tap } from "rxjs";
-import { environment } from "../../environments/environment.development";
+import { environment } from "../../environments/environment";
 
 
 @Injectable({ providedIn: 'root' })

--- a/src/users/services/user.service.ts
+++ b/src/users/services/user.service.ts
@@ -24,12 +24,12 @@ export class UserService {
       );
     }
 
-    activateUser(userId: string, activationToken: string): Observable<{ success: boolean; status: number }> {
+    activateUser(email: string, verificationCode: string): Observable<{ success: boolean; status: number }> {
       if (this.isLoading()) {
         return EMPTY;
       }
       this.isLoading.set(true);
-      return this.http.post<{ success: boolean; status: number }>(`${environment.apiUrl}/api/v1/users/${userId}/activate`, { activationToken })
+      return this.http.post<{ success: boolean; status: number }>(`${environment.apiUrl}/api/v1/users/activate`, { email, verificationCode })
         .pipe(
           tap({
             next: () => this.isLoading.set(false),

--- a/src/users/services/user.service.ts
+++ b/src/users/services/user.service.ts
@@ -14,7 +14,7 @@ export class UserService {
         return EMPTY;
       }
       this.isLoading.set(true);
-      return this.http.post<{success: boolean; status: number}>(`${environment.apiUrl}/api/v1/users/resend-activation-email`, { email })
+      return this.http.post<{success: boolean; status: number}>(`${environment.apiUrl}/users/resend-activation-email`, { email })
       .pipe(
         tap({
           next: () => this.isLoading.set(false),
@@ -29,7 +29,7 @@ export class UserService {
         return EMPTY;
       }
       this.isLoading.set(true);
-      return this.http.post<{ success: boolean; status: number }>(`${environment.apiUrl}/api/v1/users/activate`, { email, verificationCode })
+      return this.http.post<{ success: boolean; status: number }>(`${environment.apiUrl}/users/activate`, { email, verificationCode })
         .pipe(
           tap({
             next: () => this.isLoading.set(false),


### PR DESCRIPTION
## PROPINQ-114: Registro, activación y enrutamiento API (frontend)

**Base:** `dev`

Alinea el cliente Angular con backend en producción DigitalOcean: registro y activación por código, interceptor RFC 7807, y centralización de `apiUrl` con prefijo `/api/v1` para que Nginx enrute las peticiones al backend.

### Arquitectura del feature

- `environment.apiUrl`: `'/api/v1'` en producción y `'http://localhost:8080/api/v1'` en desarrollo.
- Todos los servicios concatenan `environment.apiUrl + '/ruta'` sin duplicar el prefijo en cada archivo (~18 servicios).
- Activación manual por formulario (email + código de 6 dígitos) reemplaza auto-activación por query `userId` + UUID.
- Manejo de errores centralizado en `ErrorInterceptor` compatible con RFC 7807 (`detail`).

### Servicios y contratos HTTP

- `AuthService`: login, signup, check-token y refresh-token bajo `${apiUrl}/auth/...`.
- `UserService.activateUser(email, verificationCode)` → `POST ${apiUrl}/users/activate`.
- `UserService.resendActivationEmail` → `POST ${apiUrl}/users/resend-activation-email`.
- Servicios de dominio (`properties`, `parameters`, `neighborhoods`, `buildings`, etc.) usan rutas relativas sin `/api/v1` hardcodeado.

### Páginas y componentes

- `account-activation-page`: formulario con email y código; éxito redirige a login.
- `verify-email-page`: reenvío con límite local de 3 intentos; navega a `/auth/activate?email=...` sin duplicar toasts de error.
- Eliminación de snackbars de error locales donde el interceptor global ya notifica.

### Interceptores

- `ErrorInterceptor`: lee `error.error.detail` además de `message`; sin filtrar 401/403 (alineado con producción).

### Errores solucionados

- Peticiones a `/parameters`, `/properties`, etc. sin `/api/v1` devolvían `index.html` del SPA → "Ocurrió un error inesperado".
- POST a `/auth/signup` devolvía 405 desde Nginx/frontend estático.
- Mensaje genérico ante respuestas Problem Details de Spring Boot 3.
- Alertas duplicadas al reenviar correo (interceptor + snackbar del componente).
- Loop de verificación por magic link incompatible con la UI de código.

### Archivos impactados

- `src/environments/environment.ts`, `environment.development.ts`
- `src/app/auth/services/auth.service.ts`, páginas de activación/verificación
- `src/users/services/user.service.ts` y servicios de dominio (`properties`, `parameters`, `neighborhoods`, etc.)
- `src/app/shared/interceptors/error.interceptor.ts`
- `Dockerfile.prod`, `nginx/default.conf`, `angular.json` (budgets para build de producción)

### Validación

- Pruebas manuales: home, listado de propiedades, parámetros y barrios en `propinq.online`.
- Producción: endpoints críticos responden HTTP 200 vía proxy Nginx.
- Pruebas automáticas: pendiente de E2E Cypress en rama de testing.
